### PR TITLE
Update and rename OWNERS.md to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,8 @@
+# Maintainers
+
+Maintainership is on a per project basis.
+
+### Maintainers
+ - Alberto Ricart <alberto@nats.io> [@aricart](https://github.com/aricart)
+ - Derek Collison <derek@nats.io> [@derekcollison](https://github.com/derekcollison)
+ - Ivan Kozlovic <ivan@nats.io> [@kozlovic](https://github.com/kozlovic)

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,7 +1,0 @@
-reviewers:
-- aricart
-- derekcollison
-- kozlovic
-approvers:
-- aricart
-- derekcollison


### PR DESCRIPTION
[CI SKIP]
Rename from OWNERS.md to MAINTAINERS.md
Update to MAINTAINERS.md based on newly adopted Governance and Maintainership definitions.